### PR TITLE
Cleaning up also observer--end2end

### DIFF
--- a/jenkinsfiles/Jenkinsfile.clean-end2end
+++ b/jenkinsfiles/Jenkinsfile.clean-end2end
@@ -40,5 +40,12 @@ elifePipeline {
                 builderCmd 'search--end2end', 'cd /srv/search && bin/wait-for-running-elasticsearch && php bin/console search:setup -d --env=end2end && php bin/console cache:clear --env=end2end'
             }
         }
+
+        stage "Observer", {
+            lock 'observer--end2end', {
+                builderStart 'observer--end2end'
+                builderCmd 'observer--end2end', 'cd /srv/observer && ./manage.sh flush --no-input'
+            }
+        }
     }
 }


### PR DESCRIPTION
This build cleans nightly the end2end environment, we now include this project as it refers to data coming from lax--end2end, which is already being cleaned