### PR TITLE
feat ubuntu 1604

### DIFF
--- a/salt/elife-alfred/init.sls
+++ b/salt/elife-alfred/init.sls
@@ -121,6 +121,7 @@ jenkins:
 
     service.running:
         - enable: True
+        - init_delay: 10 # seconds. attempting to fetch the jenkins-cli too early will fail
         - watch:
             - file: /etc/default/jenkins
         - require:
@@ -367,10 +368,12 @@ jenkins-workspaces-cleanup-cron:
         - name: rm -rf /var/lib/jenkins/workspace/*
         - identifier: jenkins-workspaces-cleanup-cron
 
-jenkins-diagnostic-tools:
-    pkg.installed:
-        - pkgs:
-            - openjdk-7-jdk
+# disabled. 
+# state isn't required by anything. oracle java 8 installed. openjdk has it's own state file
+#jenkins-diagnostic-tools:
+#    pkg.installed:
+#        - pkgs:
+#            - openjdk-7-jdk
 
 jenkins-cli:
     cmd.run:
@@ -378,9 +381,8 @@ jenkins-cli:
         - require:
             - jenkins
         - unless:
-            - test -e /usr/local/bin/jenkins-cli.jar
-            - test -s /usr/local/bin/jenkins-cli.jar
-            - jar tvf /usr/local/bin/jenkins-cli.jar
+            - test -s /usr/local/bin/jenkins-cli.jar # file exists and is not empty
+            - jar tvf /usr/local/bin/jenkins-cli.jar # valid jar file
             - java -jar /usr/local/bin/jenkins-cli.jar -version | grep {{ jenkins_version }}
 
     # wrapper script for the .jar


### PR DESCRIPTION
disabled installation of openjdk7
added delay after jenkins service is started to allow server to come up
removed redundant requisite