### PR TITLE
Install kubectl for the jenkins user

### DIFF
--- a/salt/elife-alfred/config/var-lib-jenkins-.kube-config_dummy
+++ b/salt/elife-alfred/config/var-lib-jenkins-.kube-config_dummy
@@ -1,0 +1,1 @@
+-- dummy configuration for testing --

--- a/salt/example.top
+++ b/salt/example.top
@@ -15,3 +15,4 @@ base:
         #- elife-alfred.spectrum-cron
         - elife.hub
         - elife.python3
+        - elife.kubectl

--- a/salt/example.top
+++ b/salt/example.top
@@ -16,3 +16,4 @@ base:
         - elife.hub
         - elife.python3
         - elife.kubectl
+        - elife.gcloud

--- a/salt/pillar/alfred.sls
+++ b/salt/pillar/alfred.sls
@@ -14,3 +14,9 @@ alfred:
             name: test-example
             minutes: 60
 
+elife:
+    kubectl:
+        directory: /var/lib/jenkins/.kube
+        username: jenkins
+        kubeconfigs:
+            config_dummy: "salt://elife-alfred/config/var-lib-jenkins-.kube-config_dummy"

--- a/salt/pillar/alfred.sls
+++ b/salt/pillar/alfred.sls
@@ -15,8 +15,7 @@ alfred:
             minutes: 60
 
 elife:
-    kubectl:
-        directory: /var/lib/jenkins/.kube
+    gcloud:
+        directory: /var/lib/jenkins/
         username: jenkins
-        kubeconfigs:
-            config_dummy: "salt://elife-alfred/config/var-lib-jenkins-.kube-config_dummy"
+        accounts: {} # cannot add accounts locally


### PR DESCRIPTION
Depends on https://github.com/elifesciences/builder-base-formula/pull/156

/cc @lsh-0 this allows Alfred to run `kubectl` to deploy `data-pipeline`, see https://github.com/elifesciences/builder-private/blob/master/pillar/alfred.sls#L9-L17 for details.