### PR TITLE
Add vault-approle integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,10 @@ The configuration of a project is chosen according to the stack where it is depl
 - Pull requests should be directed at `develop`. The project tests should always be runnable over a branch, while the end2end tests are limited to run on the mainline right now.
 - It is the project's pipeline responsibility to merge `develop` into `approved` when all automated tests are passing.
 - It is the project's pipeline responsibility to merge `approved` into `master` upon deployment into production, which happens by triggering the `prod-$PROJECT` pipeline automatically (or optionally manually upon arrival into `approved` if the project owners do not feel confident.)
+
+## Vault
+
+The pillar show [the dependency on an external Vault server](salt/pillar/alfred.sls) to be used through `vault.sh`.
+
+The `vault.sh` script authenticates using the [AppRole](https://www.vaultproject.io/docs/auth/approle.html) method and re-issues a short-lived token every time that token expires. It can be used by any build section running on the Jenkins master.
+

--- a/salt/elife-alfred/config/usr-local-bin-vault.sh
+++ b/salt/elife-alfred/config/usr-local-bin-vault.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+# needs the following environment variables:
+#VAULT_ADDR
+#VAULT_ROLE_ID
+#VAULT_SECRET_ID
+
+if ! vault token lookup > /dev/null; then
+    # login
+    vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID" > ~/.vault-token
+fi
+
+vault $@

--- a/salt/elife-alfred/vault-approle.sls
+++ b/salt/elife-alfred/vault-approle.sls
@@ -1,0 +1,29 @@
+vault-approle-environment-variables:
+    file.managed:
+        - name: /etc/profile.d/vault.sh
+        - contents: |
+            export VAULT_ADDR={{ pillar.alfred.vault.addr or '' }}
+            export VAULT_ROLE_ID={{ pillar.alfred.vault.role_id or '' }}
+            export VAULT_SECRET_ID={{ pillar.alfred.vault.role_id or '' }}
+
+    environ.setenv:
+        - value:
+            VAULT_ADDR: {{ pillar.alfred.vault.addr }}
+            VAULT_ROLE_ID: {{ pillar.alfred.vault.role_id }}
+            VAULT_SECRET_ID: {{ pillar.alfred.vault.role_id }}
+
+vault-approle-vault-wrapper:
+    file.managed:
+        - name: /usr/local/bin/vault.sh
+        - source: salt://elife-alfred/config/usr-local-bin-vault.sh
+        - mode: 755
+        - require:
+            - vault-approle-environment-variables
+
+{% if salt['elife.only_on_aws']() %}
+vault-approle-vault-wrapper:
+    cmd.run:
+        - name: /usr/local/bin/vault token lookup > /dev/null
+        - require:
+            - vault-approle-vault-wrapper
+{% endif %}

--- a/salt/elife-alfred/vault-approle.sls
+++ b/salt/elife-alfred/vault-approle.sls
@@ -20,10 +20,12 @@ vault-approle-vault-wrapper:
         - require:
             - vault-approle-environment-variables
 
-{% if salt['elife.only_on_aws']() %}
-vault-approle-vault-wrapper:
+vault-approle-vault-wrapper-smoke-test:
     cmd.run:
-        - name: /usr/local/bin/vault token lookup > /dev/null
+{% if salt['elife.only_on_aws']() %}
+        - name: /usr/local/bin/vault.sh token lookup > /dev/null
+{% else %}
+        - name: which vault.sh
+{% endif %}
         - require:
             - vault-approle-vault-wrapper
-{% endif %}

--- a/salt/elife-alfred/vault-approle.sls
+++ b/salt/elife-alfred/vault-approle.sls
@@ -4,13 +4,7 @@ vault-approle-environment-variables:
         - contents: |
             export VAULT_ADDR={{ pillar.alfred.vault.addr or '' }}
             export VAULT_ROLE_ID={{ pillar.alfred.vault.role_id or '' }}
-            export VAULT_SECRET_ID={{ pillar.alfred.vault.role_id or '' }}
-
-    environ.setenv:
-        - value:
-            VAULT_ADDR: {{ pillar.alfred.vault.addr }}
-            VAULT_ROLE_ID: {{ pillar.alfred.vault.role_id }}
-            VAULT_SECRET_ID: {{ pillar.alfred.vault.role_id }}
+            export VAULT_SECRET_ID={{ pillar.alfred.vault.secret_id or '' }}
 
 vault-approle-vault-wrapper:
     file.managed:

--- a/salt/elife-alfred/vault-approle.sls
+++ b/salt/elife-alfred/vault-approle.sls
@@ -17,7 +17,7 @@ vault-approle-vault-wrapper:
 vault-approle-vault-wrapper-smoke-test:
     cmd.run:
 {% if salt['elife.only_on_aws']() %}
-        - name: /usr/local/bin/vault.sh token lookup > /dev/null
+        - name: bash -c "source /etc/profile && /usr/local/bin/vault.sh token lookup > /dev/null"
 {% else %}
         - name: which vault.sh
 {% endif %}

--- a/salt/example.top
+++ b/salt/example.top
@@ -10,6 +10,7 @@ base:
         - elife.aws-cli
         - elife.external-volume
         - elife.vault-client
+        - elife-alfred.vault-approle
         - elife-alfred
         #- elife-alfred.postfix
         - elife.hub

--- a/salt/pillar/alfred.sls
+++ b/salt/pillar/alfred.sls
@@ -13,6 +13,10 @@ alfred:
         example:
             name: test-example
             minutes: 60
+    vault:
+        addr: null
+        role_id: null
+        secret_id: null
 
 elife:
     gcloud:


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4755

To loosely couple this with `master-server`, the token is not renewable (and renewed) like in https://github.com/elifesciences/master-server-formula/pull/8 but rather it is re-issued in case it has expired.

Nothing uses this yet, but Slack integration of failed builds and `builder` creating stacks for formula PRs will.