### PR TITLE
Clean MECA simulator

### DIFF
--- a/jenkinsfiles/Jenkinsfile.clean-end2end
+++ b/jenkinsfiles/Jenkinsfile.clean-end2end
@@ -69,6 +69,8 @@ elifePipeline {
             lock 'elife-xpub--end2end', {
                 builderStart 'elife-xpub--end2end'
                 builderCmdNode 'elife-xpub--end2end', 1, 'cd /srv/elife-xpub && TIMEOUT=30 wait-database.sh && DROP=1 setup-database.sh'
+                // MECA SFTP server simulator
+                builderCmdNode 'elife-xpub--end2end', 1, 'cd /var/nginx-public-folder/meca/ && rm *.zip'
             }
         }
     }


### PR DESCRIPTION
Files build up there, and when testing we would like to have a very short list to go through to find the right `.zip`:
```
elife@end2end--xpub:/var/nginx-public-folders/meca$ ls -l | head -n 2
total 7948
-rw-rw-rw- 1 ubuntu users 33190 Mar 25 13:49 00c68f51-e3c7-4b37-9093-f926dac9d504-meca.zip
elife@end2end--xpub:/var/nginx-public-folders/meca$ ls -l | wc -l
226
```