### PR TITLE
Add region to AWS credentials

### DIFF
--- a/salt/elife-alfred/config/var-lib-jenkins-.aws-credentials
+++ b/salt/elife-alfred/config/var-lib-jenkins-.aws-credentials
@@ -1,4 +1,5 @@
 [default]
 aws_access_key_id = {{ pillar.alfred.builder.aws.access_key_id }}
 aws_secret_access_key = {{ pillar.alfred.builder.aws.secret_access_key }}
+region = {{ pillar.alfred.builder.aws.region }}
 

--- a/salt/pillar/alfred.sls
+++ b/salt/pillar/alfred.sls
@@ -3,6 +3,7 @@ alfred:
         aws:
             access_key_id: null
             secret_access_key: null
+            region: us-east-1
     slack:
         channel_hook: null
     jenkins:


### PR DESCRIPTION
Required by `helm` or at least, its S3 plugin.