### PR TITLE
Correct typo in volume to clean

### DIFF
--- a/jenkinsfiles/Jenkinsfile.clean-end2end
+++ b/jenkinsfiles/Jenkinsfile.clean-end2end
@@ -70,7 +70,7 @@ elifePipeline {
                 builderStart 'elife-xpub--end2end'
                 builderCmdNode 'elife-xpub--end2end', 1, 'cd /srv/elife-xpub && TIMEOUT=30 wait-database.sh && DROP=1 setup-database.sh'
                 // MECA SFTP server simulator
-                builderCmdNode 'elife-xpub--end2end', 1, 'cd /var/nginx-public-folder/meca/ && rm *.zip'
+                builderCmdNode 'elife-xpub--end2end', 1, 'cd /var/nginx-public-folders/meca/ && rm *.zip'
             }
         }
     }


### PR DESCRIPTION
https://github.com/elifesciences/builder-configuration/blob/master/pillar/elife-xpub-end2end-public.sls#L8 creates a volume for the `sftp` container that simulates EJP. Inspection of `elife-xpub--end2end--1` confirms this:
```
elife@end2end--xpub:~/sftp$ docker inspect sftp | jq .[0].Mounts
[
  {
    "Type": "bind",
    "Source": "/var/nginx-public-folders/meca",
    "Destination": "/home/ejpdummy/meca",
    "Mode": "rw",
    "RW": true,
    "Propagation": "rprivate"
  }
]
```
However here there is a typo so the folder is not found. The reason we clean it is that [end2end tests iterate over a subset of these files](https://github.com/elifesciences/elife-spectrum/blob/master/spectrum/checks.py#L741) so the fewer there are, the faster the tests.