### PR TITLE
Don't fail if elife-xpub is already clean

### DIFF
--- a/jenkinsfiles/Jenkinsfile.clean-end2end
+++ b/jenkinsfiles/Jenkinsfile.clean-end2end
@@ -70,7 +70,7 @@ elifePipeline {
                 builderStart 'elife-xpub--end2end'
                 builderCmdNode 'elife-xpub--end2end', 1, 'cd /srv/elife-xpub && TIMEOUT=30 wait-database.sh && DROP=1 setup-database.sh'
                 // MECA SFTP server simulator
-                builderCmdNode 'elife-xpub--end2end', 1, 'cd /var/nginx-public-folders/meca/ && rm *.zip'
+                builderCmdNode 'elife-xpub--end2end', 1, 'cd /var/nginx-public-folders/meca/ && rm -f *.zip'
             }
         }
     }


### PR DESCRIPTION
Failures like https://alfred.elifesciences.org/job/process/job/process-clean-end2end/753/ are caused by there not being anything to remove.