### PR TITLE
Redeploy master branch to stay aligned with prod

### DIFF
--- a/jenkinsfiles/Jenkinsfile.journal-cms-restore-continuumtest
+++ b/jenkinsfiles/Jenkinsfile.journal-cms-restore-continuumtest
@@ -20,8 +20,8 @@ elifePipeline {
             builderCmd 'journal-cms--continuumtest', "cd /srv/journal-cms && scripts/restore-backup.sh"
         }
 
-        stage 'Redeploy', {
-            builderCmd 'journal-cms--continuumtest', "sudo salt-call state.highstate --retcode-passthrough"
+        stage 'Redeploy master', {
+            builderDeployRevision 'journal-cms--continuumtest', 'master'
         }
     }
 }


### PR DESCRIPTION
Since https://alfred.elifesciences.org/job/process/job/process-journal-cms-restore-continuumtest/57/ failed because the code remained on a `develop` commit that failed other builds. If we use `master` we do the same as `prod`, for a backup that comes from `prod`.