### PR TITLE
more python2 removal

### DIFF
--- a/salt/elife-alfred/init.sls
+++ b/salt/elife-alfred/init.sls
@@ -455,7 +455,7 @@ siege-log-file:
 
 tox:
     cmd.run:
-        - name: pip install tox==2.9.1
+        - name: python3 -m pip install tox==2.9.1
         - require:
             - global-python-requisites
 


### PR DESCRIPTION
* qualified usage of 'pip' as being 'python3 -m pip'
* base build is broken, see build check: https://github.com/elifesciences/elife-alfred-formula/pull/32 , this PR would fix that (`fresh` is green)