### PR TITLE
Trigger update of sciencebeam trainer grobid tag with commit ref

### DIFF
--- a/jenkinsfiles/Jenkinsfile.grobid
+++ b/jenkinsfiles/Jenkinsfile.grobid
@@ -30,7 +30,7 @@ elifePipeline {
         }
 
         stage 'Trigger grobid tag update', {
-            build job:  'dependencies/dependencies-sciencebeam-trainer-update-grobid',
+            build job:  '../dependencies/dependencies-sciencebeam-trainer-update-grobid',
                         wait: false,
                         parameters: [string(name: 'grobid_tag', value: commit)]
         }

--- a/jenkinsfiles/Jenkinsfile.grobid
+++ b/jenkinsfiles/Jenkinsfile.grobid
@@ -28,5 +28,9 @@ elifePipeline {
             unstable_image.tag(tag).push()
             unstable_image.push()
         }
+
+        stage 'Trigger grobid tag update', {
+            build job: 'dependencies/dependencies-sciencebeam-trainer-update-grobid',  wait: false, parameters: [string(name: 'grobid_tag', value: commit)]
+        }
     }
 }

--- a/jenkinsfiles/Jenkinsfile.grobid
+++ b/jenkinsfiles/Jenkinsfile.grobid
@@ -30,7 +30,9 @@ elifePipeline {
         }
 
         stage 'Trigger grobid tag update', {
-            build job: 'dependencies/dependencies-sciencebeam-trainer-update-grobid',  wait: false, parameters: [string(name: 'grobid_tag', value: commit)]
+            build job:  'dependencies/dependencies-sciencebeam-trainer-update-grobid',
+                        wait: false,
+                        parameters: [string(name: 'grobid_tag', value: commit)]
         }
     }
 }


### PR DESCRIPTION
partly resolves [#5490](https://github.com/elifesciences/issues/issues/5490). triggers ci pipeline for updating env files in sciencebeam trainer with the latest commit ref of grobid docker