### PR TITLE
added catchall condition before grobid downstream

### DIFF
--- a/jenkinsfiles/Jenkinsfile.grobid
+++ b/jenkinsfiles/Jenkinsfile.grobid
@@ -30,9 +30,11 @@ elifePipeline {
         }
 
         stage 'Trigger grobid tag update', {
-            build job:  '../dependencies/dependencies-sciencebeam-trainer-update-grobid',
-                        wait: false,
-                        parameters: [string(name: 'grobid_tag', value: commit)]
+            if (revision == 'catchall') {
+                build job:  '../dependencies/dependencies-sciencebeam-trainer-update-grobid',
+                            wait: false,
+                            parameters: [string(name: 'grobid_tag', value: commit)]
+            }
         }
     }
 }


### PR DESCRIPTION
This relates to the [process-grobid-docker](https://alfred.elifesciences.org/job/process/job/process-grobid-docker/) Jenkins task.

This should only trigger the downstream task if the revision is the default `catchall`. If I specify `master` to for example build an image for that branch, then that shouldn't trigger the downstream task.