### PR TITLE
handle grobid alternative dockerfile

### DIFF
--- a/jenkinsfiles/Jenkinsfile.grobid
+++ b/jenkinsfiles/Jenkinsfile.grobid
@@ -17,8 +17,16 @@ elifePipeline {
 
         stage "Build Image", {
             dir('grobid') {
+                def dockerfile = "Dockerfile"
+                if (new File("Dockerfile.crf")) {
+                    // GROBID 0.6.2+ contains Dockerfile.crf and Dockerfile.delft
+                    dockerfile = "Dockerfile.crf"
+                }
                 // we are using a blank version as the commit hash wouldn't be a valid version
-                sh "docker build -t elifesciences/grobid:${commit} --build-arg GROBID_VERSION= ."
+                sh "docker build \
+                    -f ${dockerfile} \
+                    -t elifesciences/grobid:${commit} \
+                    --build-arg GROBID_VERSION= ."
             }
         }
 

--- a/jenkinsfiles/Jenkinsfile.grobid
+++ b/jenkinsfiles/Jenkinsfile.grobid
@@ -18,7 +18,7 @@ elifePipeline {
         stage "Build Image", {
             dir('grobid') {
                 def dockerfile = "Dockerfile"
-                if (new File("Dockerfile.crf")) {
+                if (new File("Dockerfile.crf").exists()) {
                     // GROBID 0.6.2+ contains Dockerfile.crf and Dockerfile.delft
                     dockerfile = "Dockerfile.crf"
                 }


### PR DESCRIPTION
after merging upstream changes from GROBID (prior to 0.6.2), the build started to fail because there isn't a `Dockerfile` anymore, but instead a `Dockerfile.crf` and `Dockerfile.delft`. This is a quick fix to use the `Dockerfile.crf` if it exists (as that is equivalent to the previous `Dockerfile`)