### PR TITLE
Fix timeout for search reindex

### DIFF
--- a/jenkinsfiles/Jenkinsfile.search-reindex
+++ b/jenkinsfiles/Jenkinsfile.search-reindex
@@ -11,4 +11,4 @@ elifePipeline({
             builderCmdNode 'search--prod', 1, "cd /srv/search; ./bin/reindex elife_search_reindex_${env.BUILD_NUMBER}"
         }
     }
-}, timeoutInMinutes=240)
+}, 240)


### PR DESCRIPTION
Since https://github.com/elifesciences/elife-alfred-formula/pull/57 we have not had a successful run of this pipeline.

@giorgiosironi and I suspect this is a syntax error and this change brings it inline with the iiif pipeline with the same objective: https://github.com/elifesciences/iiif-formula/blob/master/Jenkinsfile.check-iiif-on-demand

I will try this out in jenkins before marking this "Ready for review".