### PR TITLE
builder, always non-interactive for all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In order to provide a consistent infrastructure for every project and a single d
 
 - have an executable `project_tests.sh` files which runs the project's own tests and exiting with 0 only if the tests are successful.
 - Have `project_tests.sh` produce a `build/*.xml` file with the results of the build in the standard JUnit XML format. The 'build/' folder may be used to collect other information, such as static analysis, linting and coverage results. More than one `build/*.xml` file (e.g. PHPUnit and PHPSpec) are welcome.
-- Be ready to work after the `./bldr deploy:$stackname,$cluster` command has finished running. No necessity for starting something manually when in `end2end`, `continuumtest` and `prod`. For previous environments "ready to work" means ready to run the project tests.
+- Be ready to work after the `./bldr launch:$stackname,$cluster` command has finished running. No necessity for starting something manually when in `end2end`, `continuumtest` and `prod`. For previous environments "ready to work" means ready to run the project tests.
 
 ### Configurations
 

--- a/salt/elife-alfred/init.sls
+++ b/salt/elife-alfred/init.sls
@@ -100,6 +100,7 @@ jenkins:
         - init_delay: 10 # seconds. attempting to fetch the jenkins-cli too early will fail
         - watch:
             - file: /etc/default/jenkins
+            - file: builder-non-interactive
         - require:
             - cmd: jenkins
 
@@ -204,6 +205,13 @@ add-jenkins-gitconfig:
         - mode: 664
         - require:
             - jenkins
+
+builder-non-interactive:
+    file.append:
+        - name: /etc/environment
+        - text: "BUILDER_NON_INTERACTIVE=1"
+        - unless:
+            - grep 'BUILDER_NON_INTERACTIVE=1' /etc/environment
 
 builder-project-aws-credentials-elife:
     file.managed:


### PR DESCRIPTION
Prevent blocking on stdin for calls to `utils.confirm` in builder on all tasks.

The alternative is explicitly specifying it for any Jenkinsfiles or groovy code that calls a task with a confirmation prompt, for example: 

https://github.com/elifesciences/elife-alfred-formula/blob/befd651e1aeb95c1021b53399910842e38cff20b/jenkinsfiles/Jenkinsfile.ec2-plugin-ami-update#L15