### PR TITLE
adds SALT_NO_COLOR to no /etc/environment

### DIFF
--- a/salt/elife-alfred/init.sls
+++ b/salt/elife-alfred/init.sls
@@ -211,6 +211,13 @@ builder-non-interactive:
         - unless:
             - grep 'BUILDER_NON_INTERACTIVE=1' /etc/environment
 
+builder-highstate-no-colours:
+    file.append:
+        - name: /etc/environment
+        - text: "SALT_NO_COLOR=1"
+        - unless:
+            - grep 'SALT_NO_COLOR=1' /etc/environment
+
 builder-project-aws-credentials-elife:
     file.managed:
         - name: /home/{{ pillar.elife.deploy_user.username }}/.aws/credentials


### PR DESCRIPTION
presence of a non-empty value for this envvar will tell builder's 'highstate.sh' script to disable forced coloured output