### PR TITLE
jenkins, adds a systemd service override.

### DIFF
--- a/salt/elife-alfred/config/etc-systemd-system-jenkins.service.d-override.conf
+++ b/salt/elife-alfred/config/etc-systemd-system-jenkins.service.d-override.conf
@@ -1,3 +1,4 @@
 [Service]
+EnvironmentFile=/etc/environment
 ExecStart=
 ExecStart=/bin/bash -lc /usr/bin/jenkins

--- a/salt/elife-alfred/config/etc-systemd-system-jenkins.service.d-override.conf
+++ b/salt/elife-alfred/config/etc-systemd-system-jenkins.service.d-override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/bin/bash -lc /usr/bin/jenkins


### PR DESCRIPTION
this override executes jenkins via bash so jenkins has access to envvars defined in /etc/profile.d/*