### PR TITLE
jenkinsfiles, adds 'prune_amis' task.

### DIFF
--- a/jenkinsfiles/Jenkinsfile.prune_amis
+++ b/jenkinsfiles/Jenkinsfile.prune_amis
@@ -1,0 +1,6 @@
+elifePipeline {
+    stage "Prune AMIs", {
+        def shellCmd = "${env.BUILDER_PATH}bldr tasks.delete_all_amis_to_prune"
+        sh(script: shellCmd)
+    }
+}


### PR DESCRIPTION
it calls a builder task that runs a report to find all generated AMIs older than 3 months and deregisters them and deletes the backing EBS snapshot.