### PR TITLE
journal-cms, removed 'confirm' parameter to 'restore-continuumtest' cmd.

### DIFF
--- a/jenkinsfiles/Jenkinsfile.journal-cms-restore-continuumtest
+++ b/jenkinsfiles/Jenkinsfile.journal-cms-restore-continuumtest
@@ -11,11 +11,9 @@ elifePipeline {
 
     lock (stackname) {
         stage 'Retrieve files', {
-            withEnv(['BLDR_BACKEND=threadbare']) {
-                def workingDirectory = pwd()
-                sh "${env.BUILDER_PATH}bldr upload_file:${stackname},${workingDirectory}/backups.env,/tmp/backups.env,overwrite=true,confirm=true"
-                builderCmd 'journal-cms--continuumtest', 'cd /srv/journal-cms && source /tmp/backups.env && scripts/download-backup.sh'
-            }
+            def workingDirectory = pwd()
+            sh "${env.BUILDER_PATH}bldr upload_file:${stackname},${workingDirectory}/backups.env,/tmp/backups.env,overwrite=true"
+            builderCmd 'journal-cms--continuumtest', 'cd /srv/journal-cms && source /tmp/backups.env && scripts/download-backup.sh'
         }
 
         stage 'Restore backup', {


### PR DESCRIPTION
handled by 'BUILDER_NON_INTERACTIVE' envvar now and defaults to 'yes'. this is set globally on elife-alfred in /etc/environment