### PR TITLE
adds Jenkinsfile.report-dependabot-security-alerts-by-maintainer

### DIFF
--- a/jenkinsfiles/Jenkinsfile.report-dependabot-security-alerts-by-maintainer
+++ b/jenkinsfiles/Jenkinsfile.report-dependabot-security-alerts-by-maintainer
@@ -11,7 +11,7 @@ elifePipeline {
                 def report = readJSON(text: output)
                 report.each{maintainer, project_map -> 
                     // format just this slice of the report
-                    body = writeJSON(returnText: true, json: project_map, pretty: true)
+                    body = writeJSON(returnText: true, json: project_map, pretty: 4)
 
                     //mail subject: "Results for \"process-github-repo-security-alerts\"", to: "${maintainer}", from: "alfred@elifesciences.org", replyTo: "no-reply@elifesciences.org", body: "Outstanding Dependabot alerts found:\n\n${body}\n\n${BUILD_URL}"
                     mail subject: "Results for \"process-github-repo-security-alerts\"", to: "l.skibinski@elifesciences.org", from: "alfred@elifesciences.org", replyTo: "no-reply@elifesciences.org", body: "Outstanding Dependabot alerts found for ${maintainer}:\n\n${body}\n\n${BUILD_URL}"

--- a/jenkinsfiles/Jenkinsfile.report-dependabot-security-alerts-by-maintainer
+++ b/jenkinsfiles/Jenkinsfile.report-dependabot-security-alerts-by-maintainer
@@ -1,0 +1,23 @@
+elifePipeline {
+    stage "Report", {
+        withCredentials([string(credentialsId: "process-github-repo-security-alerts", variable: 'GITHUB_TOKEN')]) {
+            // download latest list of project maintainers
+            sh('curl --header "Authorization: Bearer ${GITHUB_TOKEN}" "https://raw.githubusercontent.com/elifesciences/elife-playbook/master/maintainers-txt-report.json" --output project-maintainers.json')
+
+            // generate a report of maintainer => projects => alert-list
+            output = sh(script: 'GITHUB_TOKEN=${GITHUB_TOKEN} /usr/bin/github-repo-security-alerts project-maintainers.json', returnStdout:true)
+            output = output.trim()
+            if (output != "") {
+                def report = readJSON(text: output)
+                report.each{maintainer, project_map -> 
+                    // format just this slice of the report
+                    body = writeJSON(returnText: true, json: project_map, pretty: true)
+
+                    //mail subject: "Results for \"process-github-repo-security-alerts\"", to: "${maintainer}", from: "alfred@elifesciences.org", replyTo: "no-reply@elifesciences.org", body: "Outstanding Dependabot alerts found:\n\n${body}\n\n${BUILD_URL}"
+                    mail subject: "Results for \"process-github-repo-security-alerts\"", to: "l.skibinski@elifesciences.org", from: "alfred@elifesciences.org", replyTo: "no-reply@elifesciences.org", body: "Outstanding Dependabot alerts found for ${maintainer}:\n\n${body}\n\n${BUILD_URL}"
+                    echo "email sent to ${maintainer}"
+                }
+            }
+        }
+    }
+}

--- a/salt/elife-alfred/init.sls
+++ b/salt/elife-alfred/init.sls
@@ -470,7 +470,7 @@ github-aliases-file:
 install-github-repo-security-alerts:
     file.managed:
         - name: /usr/bin/github-repo-security-alerts
-        - source: https://github.com/elifesciences/github-repo-security-alerts/releases/download/0.0.1/linux-amd64
-        - source_hash: d476d745c3cd4b23377f3a81faad443a67425ad4fe40a1f19ddec5c6f56c3b97
+        - source: https://github.com/elifesciences/github-repo-security-alerts/releases/download/0.1.0/linux-amd64
+        - source_hash: d77952d51dd28ed9d9e0e2811ad2d3e77e4fb550787b1c935a99b07561246673
         - mode: 755
 


### PR DESCRIPTION
same as Jenkinsfile.report-dependabot-security-alerts but broken down further by maintainer and notifies each maintainer rather than techalerts. intended to be run regularly.