### PR TITLE
update-all-project-stacks, enables master-server and elife-alfred.

### DIFF
--- a/jenkinsfiles/Jenkinsfile.update-all-project-stacks
+++ b/jenkinsfiles/Jenkinsfile.update-all-project-stacks
@@ -21,7 +21,7 @@ elifePipeline({
         ["recommendations", "continuumtest,ci,end2end,prod"],
         ["redirects", "ci,prod"],
         ["search", "continuumtest,ci,end2end,prod"],
-        
+
         // no reason for these to be run sequentially
         ["elife-libraries", "powerful3", "elife-libraries--powerful3"],
         ["elife-libraries", "spectrum", "elife-libraries--spectrum"],
@@ -46,8 +46,23 @@ elifePipeline({
     parallel actions
 
     // these can't be run as part of the above.
+    // their order is debateable, but they should *not* be run in parallel.
     special_cases = [
-        ["master-server", "prod"], // requires Vault to be unlocked after restart
-        ["elife-alfred", "prod"],  // will shutdown the machine orchestrating the update!
+        // would ordinarily shutdown the machine orchestrating the update!
+        // the `elifeUpdateProjectByEnv` pipeline has special handling for `elife-alfred--prod`, 
+        // executing the update from the `elife-libraries--ci` instance.
+        ["elife-alfred", "prod"],
+
+        // Vault is unavailable after a reboot until unsealed by a highstate.
+        // Minions that:
+        // 1. depend on secrets stored in Vault that override a dummy default value
+        // 2. run a highstate between `master-server--prod` reboot and the Vault unseal
+        // *may* receive incorrect configuration.
+        ["master-server", "prod"],
     ]
+    for (int i = 0; i < special_cases.size(); i++) {
+        final project = special_cases[i][0]
+        final envlist = special_cases[i][1]
+        elifeUpdateProjectByEnv(project.toString(), envlist.toString())
+    }
 })


### PR DESCRIPTION
these two special cases cannot be executed in parallel with each other, nor in parallel with the other instances.