### PR TITLE
feat: remove conditional reverse proxy in init.sls

### DIFF
--- a/salt/elife-alfred/init.sls
+++ b/salt/elife-alfred/init.sls
@@ -120,7 +120,6 @@ jenkins-user-and-group:
         - require:
             - jenkins
 
-{% if pillar.elife.webserver.app == "caddy" %}
 reverse-proxy:
     file.managed:
         - name: /etc/caddy/sites.d/jenkins
@@ -132,15 +131,6 @@ reverse-proxy:
             - caddy-validate-config
         - listen_in:
             - service: caddy-server-service
-{% else %}
-reverse-proxy:
-    file.managed:
-        - name: /etc/nginx/sites-enabled/jenkins.conf
-        - source: salt://elife-alfred/config/etc-nginx-sites-available-jenkins.conf
-        - template: jinja
-        - watch_in:
-            - service: nginx-server-service
-{% endif %}
 
 # only needed to checkout the git projects
 jenkins-ssh:


### PR DESCRIPTION
Removed the condition that checks if the webserver app is "caddy". Now, the reverse-proxy block only manages /etc/caddy/sites.d/jenkins without any condition. The management of /etc/nginx/sites-enabled/jenkins.conf has been removed.