### PR TITLE
Remove end2end from Jenkinsfile.refresh-venv-elife-bot

### DIFF
--- a/jenkinsfiles/Jenkinsfile.refresh-venv-elife-bot
+++ b/jenkinsfiles/Jenkinsfile.refresh-venv-elife-bot
@@ -1,5 +1,5 @@
 elifePipeline {
-    ["ci", "end2end", "continuumtest", "prod"].each{ env ->
+    ["ci", "continuumtest", "prod"].each{ env ->
         stage env, {
             build job: '/process/process-refresh-venv', parameters: [string(name: 'project_name', value: 'elife-bot'), string(name: 'project_env', value: env)]
         }


### PR DESCRIPTION
This may cause https://alfred.elifesciences.org/job/process/job/process-refresh-venv-elife-bot/ to pass, my assumption is some `end2end` resources may not exist anymore?